### PR TITLE
Rocky Linux support + SSH timeout fix

### DIFF
--- a/tasks/setup-Linux.yml
+++ b/tasks/setup-Linux.yml
@@ -54,6 +54,8 @@
   shell: "make PROFILE_TASK='-m test.regrtest --pgo -j{{ make_num_threads }}' -j{{ make_num_threads }} && make altinstall"
   args:
     chdir: "/tmp/Python-{{ python_version }}"
+  async: 180000
+  poll: 60
   when: command_result.rc > 0
 
 - name: Linux | Clean dependency use for python compilation

--- a/vars/Rocky.yml
+++ b/vars/Rocky.yml
@@ -1,0 +1,16 @@
+---
+package_requirements:
+  - bzip2-devel
+  - gcc
+  - gcc-c++
+  - gdbm-devel
+  - make
+  - libuuid-devel
+  - ncurses-devel
+  - libffi-devel
+  - openssl-devel
+  - readline-devel
+  - sqlite-devel
+  - tk-devel
+  - xz-devel
+  - zlib-devel


### PR DESCRIPTION
I copied CentOS.yaml to Rocky.yaml to support RockyLinux 8.
Then also added SSH polling to the compilation step - if the SSH server is configured to terminate idle client connections this will keep it alive.

Thx for the great work!