### PR TITLE
fix(syntax): support minor version with 2 digits

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -9,43 +9,39 @@ on:
 jobs:
   test:
     name: ${{ matrix.image }} python ${{ matrix.python_version }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         image:
           - centos:8
           - centos:7
-          - fedora:35
-          - fedora:34
-          - fedora:33
-          - fedora:32
-          - fedora:31
-          - fedora:30
+          - fedora:39
+          - fedora:38
+          - ubuntu:22.04
           - ubuntu:20.04
           - ubuntu:18.04
-          - ubuntu:16.04
-          - debian:10
-          - debian:9
+          - debian:12
+          - debian:11
           - oraclelinux:8
           - oraclelinux:7
           - amazonlinux:2
           - archlinux:latest
         python_version:
-          - 3.8.5
-          - 3.7.6
-          - 3.6.10
-        exclude:
-          - {image: "ansible-fedora:32", python_version: "3.6.10"}
+          - 3.12.2
+          - 3.11.9
+          - 3.10.14
+          - 3.9.19
+          - 3.8.19
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Install Molecule
         run: |

--- a/README.md
+++ b/README.md
@@ -20,24 +20,18 @@ Supported platforms:
     - 7
 - name: Fedora
   versions:
-    - 32
-    - 31
-    - 30
-    - 29
-    - 28
-    - 27
-    - 26
+    - 39
+    - 38
 - name: Debian
   versions:
+    - bookworm
+    - bullseye
     - buster
-    - stretch
-    - jessie
 - name: Ubuntu
   versions:
-    - disco
+    - jammy
+    - focal
     - bionic
-    - xenial
-    - trusty
 - name: OracleLinux
   versions:
     - 8
@@ -50,6 +44,8 @@ Supported platforms:
     - any
 ```
 
+Probably supports older versions of the above distros too, but this is no longer tested against.
+
 ## Role Variables
 
 This role has multiple variables. The defaults for all these variables are the following:
@@ -59,8 +55,8 @@ This role has multiple variables. The defaults for all these variables are the f
 # defaults file for ansible-role-python
 
 # The version of Python to install
-# Valid values: 3.4, 3.5, 3.6, 3.7, 3.8
-python_version: 3.7.6
+# Valid values: 3.8.19, 3.9.19, 3.10.14, 3.11.9, 3.12.2
+python_version: 3.9.19
 
 # The location where to download the Python archive
 python_tarball_url: https://www.python.org/ftp/python/{{ python_version }}/Python-{{ python_version }}.tgz
@@ -95,10 +91,10 @@ This role can also install a specific version of Python.
   roles:
     - role: diodonfrost.python
       vars:
-        python_version: 3.7.6
+        python_version: 3.9.19
 ```
 
-Install Python 3.7.6 and Python 3.6.10
+Install Python 3.9.19 and Python 3.8.19
 
 ```yaml
 ---
@@ -107,10 +103,10 @@ Install Python 3.7.6 and Python 3.6.10
   roles:
     - role: diodonfrost.python
       vars:
-        python_version: 3.7.6
+        python_version: 3.9.19
     - role: diodonfrost.python
       vars:
-        python_version: 3.6.10
+        python_version: 3.8.19
 ```
 
 ## Local Testing

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,8 +2,8 @@
 # defaults file for ansible-role-python
 
 # The version of Python to install
-# Valid values: 3.4, 3.5, 3.6, 3.7, 3.8
-python_version: 3.7.6
+# Valid values: 3.8.19, 3.9.19, 3.10.14, 3.11.9, 3.12.2
+python_version: 3.9.19
 
 # The location where to download the Python archive
 python_tarball_url: https://www.python.org/ftp/python/{{ python_version }}/Python-{{ python_version }}.tgz
@@ -16,7 +16,7 @@ ensure_pip: install
 enable_optimizations: true
 
 # Define the root directory for the Python install location,
-python_path: "/usr/local/python{{ python_version[:3] }}"
+python_path: "/usr/local/python{{ python_version | regex_replace('(\\d+\\.\\d+).*', '\\1') }}"
 
 # Allow N jobs at once
 # Default use number of vcpu

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -15,7 +15,7 @@ platforms:
     privileged: yes
     pre_build_image: yes
     env:
-      python_version: "${python_version:-3.8.5}"
+      python_version: "${python_version:-3.8.19}"
 provisioner:
   name: ansible
 verifier:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -3,7 +3,7 @@
   hosts: all
   tasks:
     - name: Linux | Python should be functionnal
-      command: /usr/local/python{{ ansible_env.python_version[:3] }}/bin/python{{ ansible_env.python_version[:3] }} --version
+      command: /usr/local/python{{ ansible_env.python_version[:3] }}/bin/python{{ ansible_env.python_version | regex_replace('(\\d+\\.\\d+).*', '\\1')] }} --version
       ignore_errors: yes
       register: python_result
 

--- a/tasks/setup-Linux.yml
+++ b/tasks/setup-Linux.yml
@@ -3,7 +3,7 @@
 
 # This task avoids downloading Python archive every time
 - name: Linux | Check if Python is present with the right version
-  command: "{{ python_path }}/bin/python{{ python_version[:3] }} --version"
+  command: "{{ python_path }}/bin/python{{ python_version | regex_replace('(\\d+\\.\\d+).*', '\\1') }} --version"
   register: command_result
   ignore_errors: yes
   changed_when: false


### PR DESCRIPTION
* Previously the version string was stripped till 3 chars only
  now we pick the major[dot]minor version explicitly.

  fixes: Support for 3 digit python version #3